### PR TITLE
Add start and dev scripts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
+    "start": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "test": "echo \"Error: no test specified\" && exit 0"

--- a/server/package.json
+++ b/server/package.json
@@ -4,10 +4,14 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
+    "dev": "nodemon index.js",
     "test": "echo \"Error: no test specified\" && exit 0"
   },
   "dependencies": {
     "express": "^4.18.2",
     "sqlite3": "^5.1.2"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
   }
 }


### PR DESCRIPTION
## Summary
- enable `npm start` for the client
- add a dev script to the server with nodemon

## Testing
- `npm run dev` in `server` *(fails: nodemon not found)*
- `npm start` in `client` *(fails: vite not found)*